### PR TITLE
Add Aerial to the applications list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,6 @@ if (!androidTamperingProtection.validate()) {
 }
 ```
 
+# Applications that use AndroidTampering
+
+* [Aerial](https://play.google.com/store/apps/details?id=com.sandro.aerial)


### PR DESCRIPTION
This PR adds the `Aerial` application to the list of applications that use `AndroidTampering`.
